### PR TITLE
Include module_params within each tab within a sidebar tab

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -47,13 +47,9 @@ st_call_all_modules <- function(config, data_global, display_tab = function(x){T
         .fun <- module_tabs(.$tabs, display_tab)
       }
       if (!is.null(.fun)){
-        if (is.null(.$module_params)){
-          callModule(.fun, tabName, data_global = data_global)
-        } else {
-          l <- list(.fun, tabName, data_global = data_global)
-          l <- append(l, .$module_params)
-          do.call(callModule, l)
-        }
+        l <- list(.fun, tabName, data_global = data_global)
+        l <- append(l, .$module_params)
+        do.call(callModule, l)
       }
     })
 }

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -23,7 +23,6 @@ st_create_sidebar <- function(config, data_global,
           .$menu %>%
              map(~ {
                if (!is.null(.$href)){
-                 print("I am here...")
                  return(menuSubItem(.$text, href = .$href))
                }
                tabName = make_tab_name(.)

--- a/R/tabs.R
+++ b/R/tabs.R
@@ -8,7 +8,10 @@ module_tabs <- function(tabs, display_tab = function(x){TRUE}){
         if (!is.null(.$module)){
           .fun <- get_module(.)
           if (!is.null(.fun)){
-            callModule(.fun, tabName, data_global = data_global)
+
+            l <- list(.fun, tabName, data_global = data_global)
+            l <- append(l, .$module_params)
+            do.call(callModule, l)
           }
         }
         if (!display_tab(.$text)){


### PR DESCRIPTION
Right now we can use module_params only at the sidebar tab level. This will allow it to be used within each tab on one page.

Also simplify the code for adding module_params to the arguments in both cases.

Also removed a leftover debugging print statement.