### PR TITLE
Run display_page on each sub-item of the sidebar, not just the top level

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -22,6 +22,9 @@ st_create_sidebar <- function(config, data_global,
           .icon=   icon(.x$icon)
           .$menu %>%
              map(~ {
+               if (!display_page(.$text)) {
+                 return(NULL)
+               }
                if (!is.null(.$href)){
                  return(menuSubItem(.$text, href = .$href))
                }


### PR DESCRIPTION
Need this so that we can blacklist particular subitem ("Forecasts") on prod.